### PR TITLE
Feat: 레시피 생성 중 입력 폼 비활성화하여 사용자 경험(UX) 개선

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -50,39 +50,45 @@ const Index = () => {
           <h2 className="text-2xl md:text-3xl font-bold text-card-foreground mb-2">어떤 재료로 무엇을 만들어 볼까요?</h2>
           <p className="text-muted-foreground mb-6">냉장고 속 재료와 당신의 기분을 알려주세요. AI가 완벽한 레시피를 찾아드릴게요!</p>
 
-          <div className="space-y-6">
-            <IngredientInput
-              ingredients={inputState.ingredients}
-              onAddIngredient={(ingredient) => dispatch({ type: "ADD_INGREDIENT", payload: ingredient })}
-              onRemoveIngredient={(ingredient) => dispatch({ type: "REMOVE_INGREDIENT", payload: ingredient })}
-            />
+          <form>
+            <fieldset disabled={isLoading}>
+              <legend className="sr-only">레시피 생성 양식</legend>
+              <div className="space-y-6">
+                <IngredientInput
+                  ingredients={inputState.ingredients}
+                  onAddIngredient={(ingredient) => dispatch({ type: "ADD_INGREDIENT", payload: ingredient })}
+                  onRemoveIngredient={(ingredient) => dispatch({ type: "REMOVE_INGREDIENT", payload: ingredient })}
+                />
 
-            <PreferenceInputs
-              weather={inputState.weather}
-              mood={inputState.mood}
-              servings={inputState.servings}
-              onWeatherChange={(value) => dispatch({ type: "SET_WEATHER", payload: value })}
-              onMoodChange={(value) => dispatch({ type: "SET_MOOD", payload: value })}
-              onServingsChange={(value) => dispatch({ type: "SET_SERVINGS", payload: value })}
-            />
-          </div>
+                <PreferenceInputs
+                  weather={inputState.weather}
+                  mood={inputState.mood}
+                  servings={inputState.servings}
+                  onWeatherChange={(value) => dispatch({ type: "SET_WEATHER", payload: value })}
+                  onMoodChange={(value) => dispatch({ type: "SET_MOOD", payload: value })}
+                  onServingsChange={(value) => dispatch({ type: "SET_SERVINGS", payload: value })}
+                />
+              </div>
 
-          <div className="mt-8 text-center flex flex-col md:flex-row justify-center items-center gap-4">
-            <Button
-              onClick={handleGenerateClick}
-              disabled={isLoading || inputState.ingredients.length < 1}
-              variant="chef"
-              size="xl"
-              className="w-full md:w-auto min-w-[200px]"
-            >
-              <Zap className="mr-2" size={20} />
-              {isLoading ? "레시피 생성 중..." : "AI 레시피 생성"}
-            </Button>
-            <Button onClick={resetAllInputs} variant="outline" size="lg" className="w-full md:w-auto">
-              <RotateCcw className="mr-2" size={18} />
-              입력 초기화
-            </Button>
-          </div>
+              <div className="mt-8 text-center flex flex-col md:flex-row justify-center items-center gap-4">
+                <Button
+                  type="button"
+                  onClick={handleGenerateClick}
+                  disabled={isLoading || inputState.ingredients.length < 1}
+                  variant="chef"
+                  size="xl"
+                  className="w-full md:w-auto min-w-[200px]"
+                >
+                  <Zap className="mr-2" size={20} />
+                  {isLoading ? "레시피 생성 중..." : "AI 레시피 생성"}
+                </Button>
+                <Button type="button" onClick={resetAllInputs} variant="outline" size="lg" className="w-full md:w-auto">
+                  <RotateCcw className="mr-2" size={18} />
+                  입력 초기화
+                </Button>
+              </div>
+            </fieldset>
+          </form>
         </div>
 
         {/* Results Section */}


### PR DESCRIPTION
## 개요
AI가 레시피를 생성하는 동안 사용자가 입력을 변경하거나 중복 요청을 보내는 것을 방지하여, 사용자 경험(UX)을 개선

## 주요 변경 사항
- 입력 폼 비활성화: 
  - 모든 입력 관련 컴포넌트를 <fieldset>으로 감싸고, disabled={isLoading} 속성을 바인딩하여 로딩 상태에서 그룹 전체를 한번에 비활성화
- 시맨틱 마크업 및 접근성 강화: 
  - 입력 양식의 의미를 명확히 하기 위해 <fieldset>을 <form> 태그를 감쌈
  - 스크린 리더 사용자를 위해 <legend> 태그를 추가하여 '레시피 생성 양식'이라는 컨텍스트를 제공
- 폼 제출(Submit) 방지: 
  - <form> 태그 사용에 따른 원치 않는 페이지 새로고침을 막기 위해, 내부 버튼들에 type="button" 속성을 명시적으로 추가

## 테스트 방법
1. 애플리케이션을 실행
2. 'AI 레시피 생성' 버튼을 클릭
3. 레시피가 생성되는 동안(로딩 중) 재료 입력, 옵션 선택, 모든 버튼이 비활성화되는지 확인
4. 입력 필드에서 Enter 키를 눌러도 페이지가 새로고침되지 않는지 확인
5. 레시피 생성이 완료되면 폼이 다시 활성화 상태로 돌아오는지 확인

## 관련 이슈
- 없음